### PR TITLE
Remove unused test function that fails compilation with `expr_builder` disabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,12 +122,6 @@ lazy_static! {
     ]);
 }
 
-pub(crate) fn _test_calc() -> RRes {
-    let r = RCalc::e3(2);
-    r.calc(ROpBuilder::new().bound("R1 + R2 ~ 500").finish())
-        .unwrap()
-}
-
 /// A series of resistor values, constants are provided for standard resistor array values.
 #[derive(Debug)]
 pub struct RSeries {


### PR DESCRIPTION
The function is unused and not part of any test either, additionally what it "tests" for is covered by both the main function and doctests, so I think it's safe to remove it altogether.